### PR TITLE
Add optional `included_labels` input to filter PRs by specified labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ The direction of the sort. Can be either `asc` or `desc`. Default: `desc` when s
 
 This github action doesn't set any default parameters.
 
+### `included_labels`
+
+**Optional**
+
+Comma-separated list of labels that PRs must have to be considered for update. If not provided or empty, all PRs will be considered regardless of their labels. Labels are case-sensitive and whitespace is trimmed.
+
+Example: `"label-a, label-b"` will only consider PRs that have either `label-a` or `label-b`.
+
 ### `require_auto_merge_enabled`
 
 **Optional**
@@ -145,7 +153,7 @@ To improve security and flexibility, you can use a GitHub App token instead of a
    - Save the App ID as a repository or organization variable.
    - Save the private key as a repository or organization secret.
 
-__If you have branch protection rules, ensure the GitHub App has an exemption to bypass those rules.__
+**If you have branch protection rules, ensure the GitHub App has an exemption to bypass those rules.**
 
 #### Example Usage with GitHub App Token
 
@@ -191,4 +199,3 @@ yarn build
 ```
 
 Note: You need to run `yarn build` before commit the changes because when the action only use the compiled `dest/index.js`.
-

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
   token:
     description: 'The GitHub personal access token'
     required: true
+  included_labels:
+    required: false
+    description: 'A comma-separated list of labels that the action will consider. If a PR has any of the labels, the action will consider it.'
 
 runs:
   using: 'node20'

--- a/dest/index.js
+++ b/dest/index.js
@@ -31299,17 +31299,54 @@ const getApprovalStatus = async (pullNumber) => {
   };
 };
 
-const filterApplicablePRs = (openPRs) => {
+/**
+ * Filter PRs based on their labels
+ * @param {Array} prs - List of PRs
+ * @returns {Array} - Filtered PRs based on labels
+ */
+const filterPRsByLabels = (prs) => {
+  const includedLabels = github_core.getInput('included_labels') || '';
+  const includedLabelsArray = includedLabels.split(',').map((label) => label.trim());
+  
+  if (includedLabelsArray.length === 0 || !includedLabels) {
+    return prs;
+  }
+  
+  const filteredPRs = prs.filter((item) => {
+    return item.labels.some((label) => includedLabelsArray.includes(label.name));
+  });
+  
+  log(`Count of PRs with included labels: ${filteredPRs.length}`);
+  return filteredPRs;
+};
+
+/**
+ * Filter PRs based on their auto-merge status
+ * @param {Array} prs - List of PRs
+ * @returns {Array} - Filtered PRs based on auto-merge status
+ */
+const filterPRsByAutoMerge = (prs) => {
   const includeNonAutoMergePRs = isStringFalse(
     github_core.getInput('require_auto_merge_enabled'),
   );
+  
   if (includeNonAutoMergePRs) {
-    return openPRs;
+    return prs;
   }
-  const autoMergeEnabledPRs = openPRs.filter((item) => item.auto_merge);
+  
+  const autoMergeEnabledPRs = prs.filter((item) => item.auto_merge);
   log(`Count of auto-merge enabled PRs: ${autoMergeEnabledPRs.length}`);
   return autoMergeEnabledPRs;
 };
+
+const filterApplicablePRs = (openPRs) => {
+  // First filter by labels
+  const labelFilteredPRs = filterPRsByLabels(openPRs);
+  
+  // Then filter by auto-merge status
+  return filterPRsByAutoMerge(labelFilteredPRs);
+};
+
 /**
  * find a applicable PR to update
  */

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -162,17 +162,54 @@ export const getApprovalStatus = async (pullNumber) => {
   };
 };
 
-export const filterApplicablePRs = (openPRs) => {
+/**
+ * Filter PRs based on their labels
+ * @param {Array} prs - List of PRs
+ * @returns {Array} - Filtered PRs based on labels
+ */
+export const filterPRsByLabels = (prs) => {
+  const includedLabels = core.getInput('included_labels') || '';
+  const includedLabelsArray = includedLabels.split(',').map((label) => label.trim());
+  
+  if (includedLabelsArray.length === 0 || !includedLabels) {
+    return prs;
+  }
+  
+  const filteredPRs = prs.filter((item) => {
+    return item.labels.some((label) => includedLabelsArray.includes(label.name));
+  });
+  
+  log(`Count of PRs with included labels: ${filteredPRs.length}`);
+  return filteredPRs;
+};
+
+/**
+ * Filter PRs based on their auto-merge status
+ * @param {Array} prs - List of PRs
+ * @returns {Array} - Filtered PRs based on auto-merge status
+ */
+export const filterPRsByAutoMerge = (prs) => {
   const includeNonAutoMergePRs = isStringFalse(
     core.getInput('require_auto_merge_enabled'),
   );
+  
   if (includeNonAutoMergePRs) {
-    return openPRs;
+    return prs;
   }
-  const autoMergeEnabledPRs = openPRs.filter((item) => item.auto_merge);
+  
+  const autoMergeEnabledPRs = prs.filter((item) => item.auto_merge);
   log(`Count of auto-merge enabled PRs: ${autoMergeEnabledPRs.length}`);
   return autoMergeEnabledPRs;
 };
+
+export const filterApplicablePRs = (openPRs) => {
+  // First filter by labels
+  const labelFilteredPRs = filterPRsByLabels(openPRs);
+  
+  // Then filter by auto-merge status
+  return filterPRsByAutoMerge(labelFilteredPRs);
+};
+
 /**
  * find a applicable PR to update
  */


### PR DESCRIPTION
- Updated `action.yml` to include `included_labels` as an optional input.
- Enhanced filtering logic in to filter PRs based on the provided labels.
- Updated README.md to document the new input and its usage.